### PR TITLE
Fix for "lazy loading not working untill scroll" - Always listen when we set a new image source

### DIFF
--- a/src/angular-lazy-img-logic.js
+++ b/src/angular-lazy-img-logic.js
@@ -109,7 +109,7 @@ angular.module('angularLazyImg').factory('LazyImgMagic', [
     Photo.prototype.setSource = function(source){
       this.src = source;
       images.unshift(this);
-      if (!isListening){ startListening(); }
+      startListening();
     };
 
     Photo.prototype.removeImage = function(){


### PR DESCRIPTION
First off, great directive.

A lot of users are reporting that the lazy loading logic does not work for images already in the viewport, and that they have to force a scroll to get them to load. #27 #24 

The reason for this is probably because they are using routing such as ngRoute or ui-router. What is happening is that there is a "listening trap" occurring. When new images sources are being instantiated, we aren't triggering a listen for the new images and "isElementInView" is never reached until we scroll (or trigger window resize) This is because listening is already running without adding the new image to the array.

This PR always starts listening when a new image is added and fixes the problem, however if anyone has a better solution i'd love to hear it.
